### PR TITLE
Add missing unit tests for convert package

### DIFF
--- a/packages/convert/src/composite.test.ts
+++ b/packages/convert/src/composite.test.ts
@@ -1,8 +1,50 @@
-import {rgbToLab} from './composite'
+import {rgbToLab, labToRGB, hslToHex, hexToHSL, hslToLab, labToHex} from './composite'
 
 it('converts RGB to Lab correctly', () => {
   let lab = rgbToLab({r: 202, g: 75, b: 34})
   expect(lab.l).toBeCloseTo(49.14, 2)
   expect(lab.a).toBeCloseTo(48.575, 2)
   expect(lab.b).toBeCloseTo(48.715, 2)
+})
+
+it('converts Lab to RGB correctly', () => {
+  let rgb = labToRGB({l: 49.14, a: 48.575, b: 48.715})
+  expect(rgb.r).toBeCloseTo(202, 0)
+  expect(rgb.g).toBeCloseTo(75, 0)
+  expect(rgb.b).toBeCloseTo(34, 0)
+})
+
+it('converts Lab to RGB with strict mode returning null for out-of-gamut', () => {
+  let result = labToRGB({l: 50, a: 130, b: 130}, true)
+  expect(result).toBeNull()
+})
+
+it('converts Lab to RGB with strict=false returning placeholder for out-of-gamut', () => {
+  let result = labToRGB({l: 50, a: 130, b: 130})
+  expect(result).toEqual({r: 255, g: 0, b: 0})
+})
+
+it('converts HSL to Hex correctly', () => {
+  expect(hslToHex({h: 0, s: 1, l: 0.5})).toBe('ff0000')
+  expect(hslToHex({h: 120, s: 1, l: 0.5})).toBe('00ff00')
+  expect(hslToHex({h: 240, s: 1, l: 0.5})).toBe('0000ff')
+})
+
+it('converts Hex to HSL correctly', () => {
+  let hsl = hexToHSL('ff0000')
+  expect(hsl.h).toBe(0)
+  expect(hsl.s).toBe(1)
+  expect(hsl.l).toBe(0.5)
+})
+
+it('converts HSL to Lab correctly', () => {
+  let lab = hslToLab({h: 0, s: 1, l: 0.5})
+  expect(lab.l).toBeCloseTo(53.241, 1)
+  expect(lab.a).toBeCloseTo(80.109, 1)
+  expect(lab.b).toBeCloseTo(67.22, 1)
+})
+
+it('converts Lab to Hex correctly', () => {
+  let hex = labToHex({l: 53.233, a: 80.109, b: 67.22})
+  expect(hex).toBe('ff0000')
 })

--- a/packages/convert/src/hsl.test.ts
+++ b/packages/convert/src/hsl.test.ts
@@ -1,0 +1,59 @@
+import {hslToRGB, rgbToHSL} from './hsl'
+
+it('converts HSL to RGB for each hue sector', () => {
+  // Red (h=0)
+  expect(hslToRGB({h: 0, s: 1, l: 0.5})).toEqual({r: 255, g: 0, b: 0})
+  // Yellow (h=60)
+  expect(hslToRGB({h: 60, s: 1, l: 0.5})).toEqual({r: 255, g: 255, b: 0})
+  // Green (h=120)
+  expect(hslToRGB({h: 120, s: 1, l: 0.5})).toEqual({r: 0, g: 255, b: 0})
+  // Cyan (h=180)
+  expect(hslToRGB({h: 180, s: 1, l: 0.5})).toEqual({r: 0, g: 255, b: 255})
+  // Blue (h=240)
+  expect(hslToRGB({h: 240, s: 1, l: 0.5})).toEqual({r: 0, g: 0, b: 255})
+  // Magenta (h=300)
+  expect(hslToRGB({h: 300, s: 1, l: 0.5})).toEqual({r: 255, g: 0, b: 255})
+})
+
+it('converts achromatic HSL to RGB', () => {
+  expect(hslToRGB({h: 0, s: 0, l: 0})).toEqual({r: 0, g: 0, b: 0})
+  expect(hslToRGB({h: 0, s: 0, l: 1})).toEqual({r: 255, g: 255, b: 255})
+  expect(hslToRGB({h: 0, s: 0, l: 0.5})).toEqual({r: 128, g: 128, b: 128})
+})
+
+it('converts RGB to HSL correctly', () => {
+  let hsl = rgbToHSL({r: 255, g: 0, b: 0})
+  expect(hsl.h).toBe(0)
+  expect(hsl.s).toBe(1)
+  expect(hsl.l).toBe(0.5)
+
+  hsl = rgbToHSL({r: 0, g: 255, b: 0})
+  expect(hsl.h).toBe(120)
+  expect(hsl.s).toBe(1)
+  expect(hsl.l).toBe(0.5)
+
+  hsl = rgbToHSL({r: 0, g: 0, b: 255})
+  expect(hsl.h).toBe(240)
+  expect(hsl.s).toBe(1)
+  expect(hsl.l).toBe(0.5)
+})
+
+it('converts achromatic RGB to HSL', () => {
+  expect(rgbToHSL({r: 0, g: 0, b: 0})).toEqual({h: 0, s: 0, l: 0})
+  expect(rgbToHSL({r: 255, g: 255, b: 255})).toEqual({h: 0, s: 0, l: 1})
+})
+
+it('handles negative hue wrap-around', () => {
+  // When cmax is blue and r > g, hue formula gives negative before +360
+  let hsl = rgbToHSL({r: 100, g: 0, b: 200})
+  expect(hsl.h).toBe(270)
+})
+
+it('reversibly converts between HSL and RGB', () => {
+  let rgb = {r: 202, g: 75, b: 34}
+  let hsl = rgbToHSL(rgb)
+  let result = hslToRGB(hsl)
+  expect(Math.abs(result.r - rgb.r)).toBeLessThanOrEqual(1)
+  expect(Math.abs(result.g - rgb.g)).toBeLessThanOrEqual(1)
+  expect(Math.abs(result.b - rgb.b)).toBeLessThanOrEqual(1)
+})

--- a/packages/convert/src/lab.test.ts
+++ b/packages/convert/src/lab.test.ts
@@ -15,3 +15,22 @@ it('converts XYZ to Lab correctly', () => {
   expect(lab.a).toBeCloseTo(27.957, 2)
   expect(lab.b).toBeCloseTo(26.725, 2)
 })
+
+it('handles near-zero values using the linear branch', () => {
+  // Very small XYZ values should trigger the linear (non-cubic) branch
+  let lab = xyzToLab({x: 0.001, y: 0.001, z: 0.001})
+  expect(lab.l).toBeCloseTo(0.903, 2)
+  expect(lab.a).toBeCloseTo(0.203, 1)
+  expect(lab.b).toBeCloseTo(0.082, 1)
+
+  // And back
+  let xyz = labToXYZ(lab)
+  expect(xyz.x).toBeCloseTo(0.001, 3)
+  expect(xyz.y).toBeCloseTo(0.001, 3)
+  expect(xyz.z).toBeCloseTo(0.001, 3)
+})
+
+it('converts black (origin) correctly', () => {
+  let lab = xyzToLab({x: 0, y: 0, z: 0})
+  expect(lab.l).toBeCloseTo(0, 1)
+})

--- a/packages/convert/src/rgb.test.ts
+++ b/packages/convert/src/rgb.test.ts
@@ -72,3 +72,10 @@ it('converts Hex to RGB correctly', () => {
   expect(hexToRGB('fff')).toEqual({r: 255, g: 255, b: 255})
   expect(hexToRGB('abc')).toEqual({r: 170, g: 187, b: 204})
 })
+
+it('throws on invalid hex input', () => {
+  expect(() => hexToRGB('')).toThrow('Invalid hex code')
+  expect(() => hexToRGB('zzzzzz')).toThrow('Invalid hex code')
+  expect(() => hexToRGB('12345')).toThrow('Invalid hex code')
+  expect(() => hexToRGB('1234567')).toThrow('Invalid hex code')
+})


### PR DESCRIPTION
## Summary
- Add new `hsl.test.ts` covering all hue sectors, achromatic values, negative hue wrap-around, and round-trip fidelity
- Expand `composite.test.ts` with tests for `labToRGB` (both strict modes), `hslToHex`, `hexToHSL`, `hslToLab`, and `labToHex`
- Expand `rgb.test.ts` with `hexToRGB` error cases for invalid inputs
- Expand `lab.test.ts` with near-zero linear branch coverage and black origin conversion

## Test plan
- [x] All 25 tests pass via `vitest run`